### PR TITLE
fix(py): Cache-bust CSS by content hash, not timestamp

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-default_language_version:
-  python: python3.11
-
 exclude: "^docs/|/migrations/"
 
 repos:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-build: build/py build/js
+build: build/js build/py
 
 build/py:
 	poetry run build

--- a/src/gomashio/jinja2_filters.py
+++ b/src/gomashio/jinja2_filters.py
@@ -1,11 +1,26 @@
-import time
+import hashlib
 import urllib.parse
+from functools import cache
+from pathlib import Path
+
+from .config import DIST_DIR
+
+
+@cache
+def _digest_for(rel_path: str) -> str:
+    fs_path = Path(DIST_DIR, rel_path.lstrip("/"))
+    if not fs_path.is_file():
+        return ""
+    return hashlib.sha256(fs_path.read_bytes()).hexdigest()[:8]
 
 
 def bust_cache(s: str) -> str:
     scheme, netloc, path, query, fragment = urllib.parse.urlsplit(s)
+    digest = _digest_for(path)
+    if not digest:
+        return s
     query_dict = urllib.parse.parse_qs(query)
-    query_dict["bust"] = [time.time_ns()]
+    query_dict["bust"] = [digest]
     query = urllib.parse.urlencode(query_dict, doseq=True)
 
     return urllib.parse.urlunsplit((scheme, netloc, path, query, fragment))


### PR DESCRIPTION
## Summary

- Replace `time.time_ns()` in `bust_cache` with an 8-char SHA-256 digest of the referenced asset, memoized per path. Same bytes → same URL → real browser caching across pages and across builds.
- Reorder `make build` so `build/js` runs before `build/py`, ensuring `dist/static/output.css` exists on disk when Python renders templates.
- Drop `default_language_version: python3.11` from `.pre-commit-config.yaml` so hooks provision under whichever Python is available locally.

## Why

The old filter evaluated `time.time_ns()` on every template render. A single build produced a different `?bust=<ns>` value for each generated page, defeating cross-page browser caching. And every rebuild minted new URLs even when `output.css` was byte-identical, forcing visitors to re-fetch unchanged assets. Content-hash busting is the canonical fix.

## Test plan

- [x] `rm -rf dist && make build` succeeds.
- [x] All generated pages link to the **same** `/static/output.css?bust=<digest>` URL.
- [x] Re-running `make build` with no source change produces the **same** digest.
- [x] Modifying templates so Tailwind emits new utility classes produces a **different** digest.
- [x] `black --check src/gomashio/jinja2_filters.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)