### PR TITLE
ci(build): Bump artifact actions to v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
       - run: poetry install
       - run: npm ci
       - run: make build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: site-data
           path: ./dist
@@ -33,7 +33,7 @@ jobs:
     environment: live
     if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: site-data
           path: ./dist


### PR DESCRIPTION
## Summary
- Bumps `actions/upload-artifact` and `actions/download-artifact` from v3 to v4 in [.github/workflows/publish.yml](.github/workflows/publish.yml).

## Why
GitHub end-of-lifed v3 of the artifact actions and now hard-fails the job at the **Set up job** stage with:

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.

Nothing in the workflow body runs, so every PR build and the master deploy are blocked. v4 of upload/download must be paired (v3↔v4 mix is incompatible), so both are bumped together.

## Compatibility check
- `name` + `path` API unchanged between v3 and v4.
- The workflow uploads `site-data` once per run, so v4's immutable-artifact rule isn't an issue.
- `make build` writes only `dist/static/output.css` and `dist/**/index.html` — no dotfiles, so v4.4.0's hidden-files default exclusion has nothing to drop.
- Download still extracts into the supplied `path` (`./dist`), so the deploy step's `source: "./dist/*"` glob continues to match.

## Test plan
- [ ] CI clears the **Set up job** stage on this PR (i.e. no v3 deprecation error).
- [ ] `build` job runs `poetry install`, `npm ci`, `make build`, and uploads the `site-data` artifact successfully.
- [ ] After merge to master, the `deploy` job downloads `site-data` and the SCP step finds files under `./dist/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)