### PR TITLE
chore: Drop trailing slashes via Cloudflare assets html_handling

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,3 +3,4 @@ compatibility_date = "2026-05-08"
 
 [assets]
 directory = "./dist"
+html_handling = "drop-trailing-slash"


### PR DESCRIPTION
## Summary

- Adds `html_handling = "drop-trailing-slash"` to the `[assets]` block in `wrangler.toml`
- Cloudflare will now redirect URLs with trailing slashes (e.g. `/about/`) to their canonical form (`/about`)

## Test plan

- [ ] Deploy and verify `/about/` redirects to `/about`
- [ ] Confirm no regressions on existing page routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)