### PR TITLE
fix(content): Replace unsupported GitHub callout with styled note

### DIFF
--- a/contents/posts/pc-build.md
+++ b/contents/posts/pc-build.md
@@ -66,9 +66,9 @@ Just enable the PBO settings. Bang!
 
 ![image-20250203160621198](https://cdn.sa.net/2025/02/03/5oLRm4Kn8ZdGtkz.png)
 
-> [!NOTE]
->
->Just enable EXPO or XMP if you think this doesn't make sense to you.
+<div class="not-prose rounded-lg border-l-4 border-blue-500 bg-blue-50 p-4 text-sm">
+Just enable EXPO or XMP if you think this doesn't make sense to you.
+</div>
 
 There are lots of posts and screenshots of settings to guide you how to tweak your RAM. Overclocking 32GB x2 is a bit more physically challenging than 16GB x2, so make sure to double-check whether the post you're viewing fits your case. If you decide to buy the same RAM as I did, the screenshot above might provide some helpful clues.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -414,4 +414,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "2c2c53005c6303e5c2790de70e52aefbb57b2ae3408b4dee778c6c0b265e97c9"
+content-hash = "d4b7e75b8679851e0cd9d413ecad361b047ed021cbc1d6e85af87406e796dd1b"


### PR DESCRIPTION
## Summary
- Replace `> [!NOTE]` GitHub-style callout in the PC build post with a styled `<div>` — markdown-it-py doesn't support this syntax and rendered `[!NOTE]` as literal text in a blockquote
- The new callout uses a blue left-border + light blue background, visually distinct from blockquotes

## Test plan
- [x] Visit `/gaming-pc-build-2025` and verify the EXPO/XMP note under the RAM section renders as a styled info box, not a blockquote with `[!NOTE]` text

🤖 Generated with [Claude Code](https://claude.com/claude-code)