### PR TITLE
Fix: Sort Latest Posts by created_at descending

### DIFF
--- a/src/gomashio/cli.py
+++ b/src/gomashio/cli.py
@@ -17,6 +17,7 @@ def build():
 
     pages = Page.glob(env)
     posts = Post.glob(env)
+    posts.sort(key=lambda p: p.front_matter["created_at"], reverse=True)
     index = Index(env)
     site = Site(
         title="Aris Chow",


### PR DESCRIPTION
## Summary

- Sort posts by `created_at` descending so the "Latest Posts" index page always shows newest posts first
- `Post.glob()` uses `Path.glob()` under the hood, whose iteration order is filesystem-dependent and not guaranteed — the index page could render posts in arbitrary order

## Changes

One-line addition in `src/gomashio/cli.py`: `posts.sort(key=lambda p: p.front_matter["created_at"], reverse=True)` after collecting posts via `Post.glob(env)`.

## Test plan

- [ ] Run `build` and verify the index page lists posts from newest to oldest

🤖 Generated with [Claude Code](https://claude.com/claude-code)