### PR TITLE
fix(css): Align Latest Posts date and title columns

### DIFF
--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -7,7 +7,7 @@
   <div class="flex flex-col">
     {% for post in posts -%}
       <div class="my-2 flex-1 flex items-center">
-        <div class="mr-8 flex-initial w-fit font-sidebar">
+        <div class="mr-4 flex-none w-28 font-sidebar">
           <time
             datetime="{{ post.front_matter.created_at }}">{{ post.front_matter.created_at.strftime('%b %-d, %Y') }}</time>
         </div>


### PR DESCRIPTION
## Summary

- Homepage "Latest Posts" rows were misaligned because the date column used `w-fit`, so different glyphs in Karla (the `font-sidebar` font) produced different rendered widths, pushing each title to a different x position.
- Fix: give the date column a fixed `w-28` (and `flex-none` so it never shrinks) and tighten the gap to `mr-4`. Every title now starts at the same column regardless of which date glyphs the row contains.

## Before / after

| | date column width | title left x |
|---|---|---|
| before | 92.4 / 87.2 / 83.5 px | 466.77 / 461.58 / 457.91 px |
| after  | 112 / 112 / 112 px    | 406 / 406 / 406 px         |

(measured via `getBoundingClientRect()` against the three current posts: "Feb 23, 2025", "Oct 15, 2022", "Jun 3, 2022")

## Test plan

- [ ] `make dev`, open http://localhost:8788/, confirm all three post titles in "Latest Posts" share the same left edge.
- [ ] Resize to a narrow viewport (~375px) and confirm the date column still holds 112px and titles stay aligned without overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)