### PR TITLE
feat(seo): Per-page meta tags, sitemap, and robots.txt

### DIFF
--- a/frontend/root/robots.txt
+++ b/frontend/root/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://arisc.how/sitemap.xml

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -6,9 +6,24 @@
     <meta name="viewport"
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <meta name="og:title" content="Aris Chow">
-    <meta name="og:url" content="https://arisc.how">
-    <meta name="og:type" content="blog">
+    {% if front_matter -%}
+      {% set page_title = front_matter.title %}
+      {% set page_description = front_matter.description %}
+      {% set page_url = front_matter.canonical_url %}
+      {% set page_og_type = front_matter.og_type %}
+    {%- else -%}
+      {% set page_title = site.title %}
+      {% set page_description = site.description %}
+      {% set page_url = site.url + "/" %}
+      {% set page_og_type = "website" %}
+    {%- endif %}
+    <meta name="description" content="{{ page_description }}">
+    <link rel="canonical" href="{{ page_url }}">
+    <meta property="og:title" content="{{ page_title }}">
+    <meta property="og:description" content="{{ page_description }}">
+    <meta property="og:url" content="{{ page_url }}">
+    <meta property="og:type" content="{{ page_og_type }}">
+    <meta property="og:site_name" content="{{ site.title }}">
     <title>{% block title %}{{ site.title }}{% endblock %}</title>
     <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
     <link rel="stylesheet" href="{{ "/static/output.css" | bust_cache }}">

--- a/src/gomashio/config.py
+++ b/src/gomashio/config.py
@@ -5,3 +5,5 @@ FRONTEND_DIR = Path.joinpath(PROJECT_ROOT_DIR, "frontend")
 TEMPLATE_DIR = Path.joinpath(FRONTEND_DIR, "templates")
 CONTENTS_DIR = Path.joinpath(PROJECT_ROOT_DIR, "contents")
 DIST_DIR = Path.joinpath(PROJECT_ROOT_DIR, "dist")
+
+SITE_URL = "https://arisc.how"

--- a/src/gomashio/core.py
+++ b/src/gomashio/core.py
@@ -1,15 +1,45 @@
+import re
 import shutil
 from pathlib import Path
+from xml.etree.ElementTree import Element, SubElement, tostring
 
 import frontmatter
 import jinja2
 from markdown_it import MarkdownIt
 from slugify import slugify
 
-from .config import CONTENTS_DIR, DIST_DIR, FRONTEND_DIR
+from .config import CONTENTS_DIR, DIST_DIR, FRONTEND_DIR, SITE_URL
 from .social_link import SocialLink
 
 md = MarkdownIt().enable("table")
+
+
+def extract_description(markdown_text: str, limit: int = 160) -> str:
+    paragraphs = re.split(r"\n\s*\n", markdown_text.strip())
+    for raw in paragraphs:
+        para = raw.strip()
+        if not para:
+            continue
+        first_char = para[0]
+        if first_char in "#`|<":
+            continue
+        if first_char == ">":
+            para = "\n".join(line.lstrip(">").lstrip() for line in para.splitlines())
+        para = re.sub(r"\[\^[^\]]+\]", "", para)
+        para = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", para)
+        para = re.sub(r"\[([^\]]+)\]\[[^\]]*\]", r"\1", para)
+        para = re.sub(r"[*_`]", "", para)
+        para = re.sub(r"\s+", " ", para).strip()
+        if not para:
+            continue
+        if len(para) <= limit:
+            return para
+        truncated = para[:limit]
+        last_space = truncated.rfind(" ")
+        if last_space > 0:
+            truncated = truncated[:last_space]
+        return truncated + "…"
+    return ""
 
 
 class Menu:
@@ -21,6 +51,7 @@ class Menu:
 class Page:
     TEMPLATE_FILENAME = "page.html"
     MARKDOWN_DIR = "pages"
+    OG_TYPE = "website"
 
     def __init__(
         self,
@@ -34,6 +65,7 @@ class Page:
         with open(CONTENTS_DIR / self.MARKDOWN_DIR / self.content_filename, "r") as f:
             self.front_matter, original_markdown = frontmatter.parse(f.read())
             self.content = md.render(original_markdown)
+            self.description_fallback = extract_description(original_markdown)
 
     def __str__(self):
         return f"<{self.__class__.__name__}: {self.filename}>"
@@ -55,11 +87,16 @@ class Page:
 
     @property
     def data(self):
+        fm = {**self.front_matter}
+        if not fm.get("description"):
+            fm["description"] = self.description_fallback
+        fm["canonical_url"] = f"{SITE_URL}/{self.filename}"
+        fm["og_type"] = self.OG_TYPE
         return {
             "page": {
                 "content": self.content,
             },
-            "front_matter": {**self.front_matter},
+            "front_matter": fm,
         }
 
     def render(self, dest_dir: Path, data=None):
@@ -75,6 +112,7 @@ class Page:
 class Post(Page):
     TEMPLATE_FILENAME = "post.html"
     MARKDOWN_DIR = "posts"
+    OG_TYPE = "article"
 
 
 class Index:
@@ -88,6 +126,26 @@ class Index:
 
         template = self._env.get_template("index.html")
         (dest_dir / self.dest_filename).write_text(template.render(data))
+
+
+class Sitemap:
+    def __init__(self, dest_filename: str = "sitemap.xml"):
+        self.dest_filename = dest_filename
+
+    def render(self, dest_dir: Path, pages: list[Page], posts: list[Post]):
+        urlset = Element(
+            "urlset", xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        )
+        home = SubElement(urlset, "url")
+        SubElement(home, "loc").text = f"{SITE_URL}/"
+        for item in (*posts, *pages):
+            url_el = SubElement(urlset, "url")
+            SubElement(url_el, "loc").text = f"{SITE_URL}/{item.filename}"
+            created_at = item.front_matter.get("created_at")
+            if created_at and hasattr(created_at, "date"):
+                SubElement(url_el, "lastmod").text = created_at.date().isoformat()
+        xml_bytes = tostring(urlset, encoding="utf-8", xml_declaration=True)
+        (dest_dir / self.dest_filename).write_bytes(xml_bytes)
 
 
 class Site:
@@ -113,6 +171,7 @@ class Site:
             "site": {
                 "title": self.title,
                 "description": "Someone who owns yet another blog.",
+                "url": SITE_URL,
             },
             "menus": self.menus,
             "social_links": self.social_links,
@@ -122,6 +181,7 @@ class Site:
         for p in (*self.pages, *self.posts):
             p.render(DIST_DIR, {**self.data, **p.data})
         self.index.render(DIST_DIR, {**self.data, "posts": self.posts})
+        Sitemap().render(DIST_DIR, self.pages, self.posts)
 
     @staticmethod
     def copy_static_files():
@@ -129,6 +189,9 @@ class Site:
         static_dest.mkdir(parents=True, exist_ok=True)
         for p in (FRONTEND_DIR / "static").glob("*"):
             (static_dest / p.name).write_bytes(p.read_bytes())
+        for p in (FRONTEND_DIR / "root").glob("*"):
+            if p.is_file():
+                (DIST_DIR / p.name).write_bytes(p.read_bytes())
 
     @staticmethod
     def cleanup():


### PR DESCRIPTION
## Summary

Threads per-page SEO metadata through the existing front matter → Jinja2 → static HTML pipeline. Adds a build-time `sitemap.xml` and a static `robots.txt`.

Before: every page emitted the same hardcoded `og:title="Aris Chow"` / `og:url="https://arisc.how"`, no `<meta name="description">`, no canonical, no sitemap. Link unfurls in Slack/iMessage/X showed "Aris Chow" for every post regardless of which one was linked, and search engines had to guess each page's summary from raw `<title>` + body text.

## What changed

- **Per-page `og:*` and `<meta name="description">`** in `base.html`, driven by front matter with a site-wide fallback for the home page. Fixed `name="og:*"` → `property="og:*"` along the way.
- **`og:type`** is `article` for posts, `website` for pages and the home — set via class attributes (`Post.OG_TYPE`, `Page.OG_TYPE`), no front matter required.
- **Description auto-extracted** from the first markdown paragraph (skips headings, code blocks, tables, HTML; unwraps blockquotes; strips inline markdown; truncates to 160 chars on a word boundary). Opt-in `description:` front matter field overrides it.
- **Canonical URLs** (and sitemap entries) omit trailing slashes to match `wrangler.toml`'s `html_handling = "drop-trailing-slash"` — avoids pointing search engines at URLs that immediately redirect. The home page keeps `/`.
- **`SITE_URL`** centralized in `src/gomashio/config.py` — single source of truth for absolute URLs in canonical, sitemap, and Open Graph tags.
- **`sitemap.xml`** generated by a new `Sitemap` class in `core.py`, with `<lastmod>` from `created_at` where present (pages without that field, e.g. about, omit it).
- **`robots.txt`** shipped as a plain file at `frontend/root/robots.txt`; `Site.copy_static_files()` now also copies anything in `frontend/root/` to the dist root, so future `_redirects`/`_headers`/`humans.txt` can drop in the same way.

## Why

- Search engines get per-page summaries and a sitemap they can crawl, which improves discovery and how snippets render in SERPs.
- Slack/X/iMessage link previews now show the post title + first paragraph instead of the generic site name on every link.
- Centralizing `SITE_URL` means no more hardcoded domain strings scattered across templates.

## Reviewer notes

- The auto-extract isn't perfect for posts that lead with a heading-then-blockquote: e.g. `documenting-using-docstrings` ends up with `__doc__` rendered as plain `doc` because backticks and underscores are stripped as markdown syntax. Add `description: "..."` to the post's front matter if you want to override.
- `frontend/root/robots.txt` hardcodes the sitemap URL rather than interpolating from `SITE_URL` — small trade-off for keeping it a plain static file. If the domain ever changes, update `config.py` + `robots.txt`.
- Generated output for a post:
  ```html
  <meta name="description" content="After four years, I have finally built a new PC.">
  <link rel="canonical" href="https://arisc.how/gaming-pc-build-2025">
  <meta property="og:title" content="PC Build for Gaming (2025)">
  <meta property="og:type" content="article">
  ```

## Test plan

- [x] `make build` succeeds with no warnings
- [x] `dist/index.html` has site-wide description, `og:type=website`, canonical = `https://arisc.how/`
- [x] `dist/<post-slug>/index.html` has post-specific description (auto-extracted), `og:type=article`, canonical = `https://arisc.how/<slug>` (no trailing slash)
- [x] `dist/about/index.html` has page description, `og:type=website`, canonical = `https://arisc.how/about`
- [x] `dist/sitemap.xml` parses as valid XML and lists `/` + all posts + all pages with `<lastmod>` on dated entries
- [x] `dist/robots.txt` contains `Sitemap: https://arisc.how/sitemap.xml`
- [ ] After deploy: paste a post URL into Slack and confirm the unfurl shows the post title + first-paragraph description

🤖 Generated with [Claude Code](https://claude.com/claude-code)