### PR TITLE
Add mobile sidebar toggle button

### DIFF
--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -19,7 +19,7 @@
 <body class="flex box-border flex-col font-sans">
 <div class="box-border flex md:flex-row flex-col h-auto md:min-h-screen">
   <div class="box-border flex-initial w-auto md:w-60 px-4 md:pb-16 bg-[#1d1d1d]">
-    <div class="sticky top-16 flex flex-row md:flex-col box-border justify-start items-stretch overflow-hidden">
+    <div class="sticky top-16 flex flex-col box-border justify-start items-stretch overflow-hidden">
       <header class="flex flex-row md:flex-col items-center py-4 sm:p-6">
         <div class="px-2 md:px-0">
           <img
@@ -33,13 +33,25 @@
             {{ site.description }}
           </p>
         </div>
+        <button id="sidebar-menu-toggle"
+                type="button"
+                class="ml-auto md:hidden p-2 text-[#aaa] hover:text-amber-300 transition-[color] duration-300 ease"
+                aria-controls="sidebar-menu"
+                aria-expanded="false"
+                aria-label="Toggle navigation menu">
+          <svg class="h-6 w-6 fill-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <path d="M3 6h18v2H3V6zm0 5h18v2H3v-2zm0 5h18v2H3v-2z"/>
+          </svg>
+        </button>
       </header>
-      {% with menus=menus %}
-        {% include "sidebar/navigation.html" %}
-      {% endwith %}
-      {% with social_links=social_links %}
-        {% include "sidebar/social_links.html" %}
-      {% endwith %}
+      <div id="sidebar-menu" class="hidden md:contents">
+        {% with menus=menus %}
+          {% include "sidebar/navigation.html" %}
+        {% endwith %}
+        {% with social_links=social_links %}
+          {% include "sidebar/social_links.html" %}
+        {% endwith %}
+      </div>
     </div>
   </div>
   <div class="box-border flex flex-col px-[6vw] md:px-[6vw] lg:px-[8vw] py-[5vw] md:py-[2vw] pt-[6vw] md:pt-[6vw]">
@@ -49,5 +61,15 @@
     {% include "footer.html" %}
   </div>
 </div>
+<script>
+  (function () {
+    var btn = document.getElementById('sidebar-menu-toggle');
+    var menu = document.getElementById('sidebar-menu');
+    btn.addEventListener('click', function () {
+      var nowHidden = menu.classList.toggle('hidden');
+      btn.setAttribute('aria-expanded', nowHidden ? 'false' : 'true');
+    });
+  })();
+</script>
 </body>
 </html>

--- a/frontend/templates/sidebar/navigation.html
+++ b/frontend/templates/sidebar/navigation.html
@@ -7,7 +7,7 @@
   </li>
 {%- endmacro %}
 
-<div class="hidden md:block">
+<div>
   <nav class="mx-0 flex flex-col box-border m-12 text-center">
     <ul class="mx-6 flex-1 items-center justify-center border-b border-solid border-[#282828]">
       {% for m in menus -%}

--- a/frontend/templates/sidebar/social_links.html
+++ b/frontend/templates/sidebar/social_links.html
@@ -8,7 +8,7 @@
   </a>
 {%- endmacro %}
 
-<div class="mx-8 box-border my-4 justify-center text-[#666] hidden md:flex md:flex-row md:flex-1">
+<div class="mx-8 box-border my-4 justify-center text-[#666] flex flex-row flex-1">
   {% for sl in social_links -%}
     {{ icon(sl.name, sl.url, sl.view_box, sl.svg_data) }}
   {%- endfor %}


### PR DESCRIPTION
## Summary
- Adds a hamburger button in the top-right of the mobile sidebar that toggles the nav links and social icons into view. Previously both were `hidden md:…` with no way to reach them on screens <768px.
- The wrapper around the nav/social includes uses `hidden md:contents` so the desktop layout is byte-identical to before — only mobile behavior changes.
- A small inline script in `base.html` flips `aria-expanded` on click for accessibility.

## Test plan
- [x] `make build` runs clean
- [x] Desktop (≥768px): sidebar looks identical to before — no hamburger
- [x] Mobile (<768px): hamburger renders top-right of the sidebar strip; tap reveals nav + social icons; tap again hides
- [x] `aria-expanded` flips between `"true"` and `"false"` on toggle
- [ ] Eyeball-check on a real phone after merge/deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)