### PR TITLE
fix(dev): Make `make dev` always serve the worktree's dist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ Custom static site generator for https://arisc.how. Python + Jinja2 + Tailwind C
 ## Development
 
 ```sh
-poetry install && npm install   # first time / fresh worktree setup
-make dev                        # build + serve at localhost:8788 + auto-rebuild on file changes
+poetry install   # first time / fresh worktree setup (npm install is automatic via make)
+make dev         # build + serve at localhost:8788 + auto-rebuild on file changes
 ```
 
 ## Build
@@ -17,9 +17,7 @@ make dev                        # build + serve at localhost:8788 + auto-rebuild
 
 All paths in the Makefile, Python config, wrangler.toml, and tailwind.config.js are relative. `make dev` works from any worktree root -- never hardcode absolute paths.
 
-A fresh worktree needs setup before the first build:
-1. `npm install` -- node_modules/ is gitignored
-2. `poetry install` -- Poetry creates a separate venv per directory
+A fresh worktree needs `poetry install` before the first build (Poetry creates a separate venv per directory). `make dev` and `make build` auto-run `npm install` when `node_modules/` is missing or `package.json` has changed.
 
 ## Code style
 

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,16 @@ build: build/js build/py
 build/py:
 	poetry run build
 
-build/js:
+build/js: node_modules
 	npx tailwindcss -o "./dist/static/output.css"
 
-dev: build
+node_modules: package.json
+	npm install
+	@touch node_modules
+
+dev: node_modules build
 	trap 'kill 0' EXIT; \
-	npx wrangler pages dev ./dist & \
+	npx wrangler pages dev "$(CURDIR)/dist" & \
 	watchman-make -p 'frontend/**' 'contents/**' 'src/**' 'Makefile*' -t build
 
 watch:


### PR DESCRIPTION
## Summary
- In a fresh worktree (no local `node_modules/`), `npx wrangler` walked up to the main repo's `node_modules/`. Wrangler then computed its project root from its own script path and silently served the **main repo's** `./dist` instead of the worktree's — file edits showed up on disk but the dev server kept returning stale HTML, with no error.
- Adds `node_modules` as a Make target depending on `package.json` (with `@touch` for idempotence). `build/js` and `dev` now depend on it, so `npm install` runs automatically when missing or out of date.
- Belt-and-suspenders: wrangler now gets `"$(CURDIR)/dist"` (absolute path) — even if the upward `npx` walk reappears for any reason, wrangler can no longer mis-resolve the tree.
- CLAUDE.md updated: only `poetry install` remains a manual step for fresh-worktree setup.

## Test plan
- [x] Cold path from a fresh worktree: `rm -rf node_modules && make dev` runs `npm install` → Tailwind → Python build → wrangler boots on `:8788`
- [x] `md5` of served HTML matches `md5` of `dist/index.html` (was different in the broken state)
- [x] `lsof` on the wrangler PID points at files under the worktree's `dist/`, not the main repo's
- [x] Idempotence: `make -q node_modules` succeeds — a second `make dev` skips `npm install`
- [x] `touch package.json && make -n node_modules` shows `npm install` would re-run
- [ ] Sanity check from the main repo (non-worktree) that `make dev` still works there

🤖 Generated with [Claude Code](https://claude.com/claude-code)