### PR TITLE
feat(seo): Add og:image and Twitter Card meta tags

### DIFF
--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -24,6 +24,13 @@
     <meta property="og:url" content="{{ page_url }}">
     <meta property="og:type" content="{{ page_og_type }}">
     <meta property="og:site_name" content="{{ site.title }}">
+    <meta property="og:image" content="{{ site.image }}">
+    <meta property="og:image:alt" content="{{ site.title }}">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{{ page_title }}">
+    <meta name="twitter:description" content="{{ page_description }}">
+    <meta name="twitter:image" content="{{ site.image }}">
+    <meta name="twitter:image:alt" content="{{ site.title }}">
     <title>{% block title %}{{ site.title }}{% endblock %}</title>
     <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
     <link rel="stylesheet" href="{{ "/static/output.css" | bust_cache }}">

--- a/src/gomashio/core.py
+++ b/src/gomashio/core.py
@@ -172,6 +172,10 @@ class Site:
                 "title": self.title,
                 "description": "Someone who owns yet another blog.",
                 "url": SITE_URL,
+                "image": (
+                    "https://en.gravatar.com/userimage/107347778/"
+                    "262e4cf9b534c3017d7faa0538120fa3.jpg?size=400"
+                ),
             },
             "menus": self.menus,
             "social_links": self.social_links,


### PR DESCRIPTION
## What

Adds `og:image` and a full set of Twitter Card meta tags to every page so blog URLs render as rich cards (with logo) when shared on X and other platforms.

- `frontend/templates/base.html` — adds `og:image`, `og:image:alt`, and `twitter:card`/`twitter:title`/`twitter:description`/`twitter:image`/`twitter:image:alt`.
- `src/gomashio/core.py` — adds a `site.image` value (gravatar avatar at `size=400`) so the card image is defined once and shared by all pages.

## Why

The site already emitted Open Graph `title`/`description`/`url`/`type`/`site_name`, but **no image** — and X only renders a rich card when it finds an image plus (ideally) explicit `twitter:card` metadata. Without these, shared links showed as bare text instead of a card.

## Notes for reviewers

- Card type is `summary` (square logo thumbnail beside text), chosen because the only suitable image is the square gravatar avatar. A `summary_large_image` card would crop/letterbox it badly. If a proper 1200×630 banner is added later, switch the type and repoint `site.image`.
- Per-page titles/descriptions flow through to the Twitter tags; the homepage falls back to the site defaults.
- Verified by building locally and grepping the generated `dist/` HTML for both the homepage and a post.
- Behavior caveats (not code): X crawls the live `arisc.how` URL, so this only takes effect after deploy; and X caches cards per URL (~7 days), so already-shared links may need a cache-busting query string to refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)